### PR TITLE
Revert "Added special filter for same class OR category"

### DIFF
--- a/home.php
+++ b/home.php
@@ -93,7 +93,7 @@ add_action('wp_enqueue_scripts', 'load_my_script');¡*/
   global $wp;
   $tag = '';
   $requested = explode('/', $wp->request);
-  if($requested[0]=='tag' || $requested[0]=='both'){
+  if($requested[0]=='tag'){
     $tag = $requested[1];
   }
 ?>
@@ -119,7 +119,7 @@ add_action('wp_enqueue_scripts', 'load_my_script');¡*/
           </a>
         </li>
         <li class="community">
-          <a href="/both/community" class="<?php echo $tag=='community'?' active':'' ?>">
+          <a href="/tag/community" class="<?php echo $tag=='community'?' active':'' ?>">
             <img src="<?php bloginfo( 'template_url' ); ?>/img/filters/<?php echo $tag=='community'?'active':'normal' ?>_07.png">
           </a>
         </li>

--- a/js/main.js
+++ b/js/main.js
@@ -390,10 +390,6 @@ DaveHakkens.Main = function(){
       console.log('category in URL');
       var category = pathname.replace('/category/','');
       category = category.replace('/','');
-    } else if ( pathname.indexOf('both') !== -1 ) { // if special both in URL
-      console.log('both in URL');
-      var both = pathname.replace('/both/','');
-      both = both.replace('/','');
     }
     if(stickyPosts === undefined){
       stickyPosts = 0;
@@ -405,7 +401,7 @@ DaveHakkens.Main = function(){
     $loader.show();
     $.ajax({
       type       : "GET",
-      data       : {numPosts : numPosts, pageNumber: page, both: both, tag: tag, category: category, skipPosts: skipPosts, stickyPosts: stickyPosts, format: format},
+      data       : {numPosts : numPosts, pageNumber: page, tag: tag, category: category, skipPosts: skipPosts, stickyPosts: stickyPosts, format: format},
       dataType   : "html",
       url        : templateURL + "/loopHandler.php",
       beforeSend : function(){

--- a/loopHandler.php
+++ b/loopHandler.php
@@ -15,7 +15,6 @@ if( $_GET['skipPosts'] != '' ){
 
 $numPosts = (isset($_GET['numPosts'])) ? $_GET['numPosts'] : 10;
 $page = (isset($_GET['pageNumber'])) ? $_GET['pageNumber'] : 1;
-$both = (isset($_GET['both'])) ? $_GET['both'] : "";
 $tag = (isset($_GET['tag'])) ? $_GET['tag'] : "";
 $category = (isset($_GET['category'])) ? $_GET['category'] : "";
 $catID = get_term_by('name', $category, 'category');
@@ -30,21 +29,6 @@ $queryArgs = array(
   'cat'            => $catID,
   'ignore_sticky_posts' => 1,
 );
-if($both!=""){
-  $queryArgs['tax_query'] = array(
-    'relation' => 'OR',
-    array(
-      'taxonomy' => 'category',
-      'field' => 'slug',
-      'terms' => array($both)
-    ),
-    array(
-      'taxonomy' => 'post_tag',
-      'field' => 'slug',
-      'terms' => array($both)
-    )
-  );
-}
 
 $sticky = get_option( 'sticky_posts' );
 if($_GET['stickyPosts'] == true){


### PR DESCRIPTION
Reverts hakkens/davehakkens#45

Was overkill. Just needed the remove this snippet from function.php

//Exclude community category from main query
function exclude_category( $query ) {
	// EXCLUDE COMMUNITY CATEGORY POSTS FROM HOMEPAGE AND TAG ARCHVIES
    if ( $query->is_home() || $query->is_tag() ) {
        $query->set( 'cat', '-621' );
    }
}
add_action( 'pre_get_posts', 'exclude_category' );