### PR TITLE
change where register message appears

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -29,10 +29,10 @@ function allow_origin() {
 }
 
 //Load php partials for particular parts of BP
-function action_bp_before_register_page() {
+function action_bp_before_account_details_fields() {
   include_once 'register-message.php';
 }
-add_action('bp_before_register_page', 'action_bp_before_register_page');
+add_action('bp_before_account_details_fields', 'action_bp_before_account_details_fields');
 
 function action_bp_before_activation_page() {
   include_once 'activate-message.php';


### PR DESCRIPTION
This will now make the register message appear above the "account fields" rather than on the top of the page. It does have slightly different styling now, but it's a bit more consistent with the form on my local dev copy. Might need to change the style on the register-message.php page now.